### PR TITLE
changed react scripts to be more accurate

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon backend/server/index.js",
-    "react-dev": "webpack",
-    "react-watch": "webpack --mode development -w",
+    "react-prod": "webpack --mode production",
+    "react-dev": "webpack --mode development -w",
     "watch:css": "postcss src/assets/tailwind.css -o src/assets/main.css"
   },
   "repository": {


### PR DESCRIPTION
react-dev is not react-prod (and sets mode to production specifically), react-watch is now react-dev (since we're using it during development)